### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:alpine3.18
+
+# use PROXY_ARGS to pass flags to the proxy via command line
+# see the README for supported flags.
+ENV PROXY_ARGS ""
+
+# install the proxy code in the container
+WORKDIR /macproxy
+COPY . .
+RUN pip3 install -r requirements.txt
+
+# command to execute when container runs
+CMD python3 proxy.py ${PROXY_ARGS}


### PR DESCRIPTION
Thanks so much for your additions to macproxy on this fork, @rdmark. I've been using the script for a couple of days and it's been a lot of fun to use my G4 iMac on the web again.

I put together a simple Dockerfile for the script, since I prefer to containerize services I run on my NAS. I've [published](https://hub.docker.com/r/eveningindie/macproxy/tags) the container on Docker Hub, and thought I'd share the change here for your consideration, since I know this fork gets quite a bit of attention in retro computing forums.

If you're interested in merging this PR, I'd also be glad to add some updates to the README to highlight the Docker support. Just let me know.

Any comments or feedback you have are appreciated. Thanks!